### PR TITLE
fix(Storybook): Fix issue with table docs

### DIFF
--- a/src/stories/grid/grid.stories.js
+++ b/src/stories/grid/grid.stories.js
@@ -1,9 +1,4 @@
-import { addDecorator } from '@storybook/vue'
-
 import './grid-demo-styles.scss';
-
-var decoratorVueTemplate = () => ({ template: `<div class="grid-demo"><story/></div>` });
-addDecorator(decoratorVueTemplate);
 
 export default {
   title: 'Layout/Grid',
@@ -12,179 +7,181 @@ export default {
 
 export const Basic = () => ({
   template: `
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col">
-          <div class="outside">
-            <div class="inside">
-              1
+    <div class="grid-demo">
+      <div class="bx--grid">
+        <div class="bx--row">
+          <div class="bx--col">
+            <div class="outside">
+              <div class="inside">
+                1
+              </div>
+            </div>
+          </div>
+          <div class="bx--col">
+            <div class="outside">
+              <div class="inside">
+                1
+              </div>
+            </div>
+          </div>
+          <div class="bx--col">
+            <div class="outside">
+              <div class="inside">
+                1
+              </div>
+            </div>
+          </div>
+          <div class="bx--col">
+            <div class="outside">
+              <div class="inside">
+                1
+              </div>
+            </div>
+          </div>
+          <div class="bx--col">
+            <div class="outside">
+              <div class="inside">
+                1
+              </div>
+            </div>
+          </div>
+          <div class="bx--col">
+            <div class="outside">
+              <div class="inside">
+                1
+              </div>
+            </div>
+          </div>
+          <div class="bx--col">
+            <div class="outside">
+              <div class="inside">
+                1
+              </div>
+            </div>
+          </div>
+          <div class="bx--col">
+            <div class="outside">
+              <div class="inside">
+                1
+              </div>
+            </div>
+          </div>
+          <div class="bx--col">
+            <div class="outside">
+              <div class="inside">
+                1
+              </div>
+            </div>
+          </div>
+          <div class="bx--col">
+            <div class="outside">
+              <div class="inside">
+                1
+              </div>
+            </div>
+          </div>
+          <div class="bx--col">
+            <div class="outside">
+              <div class="inside">
+                1
+              </div>
+            </div>
+          </div>
+          <div class="bx--col">
+            <div class="outside">
+              <div class="inside">
+                1
+              </div>
+            </div>
+          </div>
+          <div class="bx--col">
+            <div class="outside">
+              <div class="inside">
+                1
+              </div>
+            </div>
+          </div>
+          <div class="bx--col">
+            <div class="outside">
+              <div class="inside">
+                1
+              </div>
+            </div>
+          </div>
+          <div class="bx--col">
+            <div class="outside">
+              <div class="inside">
+                1
+              </div>
+            </div>
+          </div>
+          <div class="bx--col">
+            <div class="outside">
+              <div class="inside">
+                1
+              </div>
             </div>
           </div>
         </div>
-        <div class="bx--col">
-          <div class="outside">
-            <div class="inside">
-              1
+        <div class="bx--row">
+          <div class="bx--col">
+            <div class="outside">
+              <div class="inside">
+                1/4
+              </div>
+            </div>
+          </div>
+          <div class="bx--col">
+            <div class="outside">
+              <div class="inside">
+                1/4
+              </div>
+            </div>
+          </div>
+          <div class="bx--col">
+            <div class="outside">
+              <div class="inside">
+                1/4
+              </div>
+            </div>
+          </div>
+          <div class="bx--col">
+            <div class="outside">
+              <div class="inside">
+                1/4
+              </div>
             </div>
           </div>
         </div>
-        <div class="bx--col">
-          <div class="outside">
-            <div class="inside">
-              1
+        <div class="bx--row">
+          <div class="bx--col">
+            <div class="outside">
+              <div class="inside">
+                1/2
+              </div>
+            </div>
+          </div>
+          <div class="bx--col">
+            <div class="outside">
+              <div class="inside">
+                1/2
+              </div>
             </div>
           </div>
         </div>
-        <div class="bx--col">
-          <div class="outside">
-            <div class="inside">
-              1
+        <div class="bx--row">
+          <div class="bx--col-sm-12 bx--col-md-4">
+            <div class="outside">
+              <div class="inside">
+                1/2
+              </div>
             </div>
           </div>
-        </div>
-        <div class="bx--col">
-          <div class="outside">
-            <div class="inside">
-              1
-            </div>
-          </div>
-        </div>
-        <div class="bx--col">
-          <div class="outside">
-            <div class="inside">
-              1
-            </div>
-          </div>
-        </div>
-        <div class="bx--col">
-          <div class="outside">
-            <div class="inside">
-              1
-            </div>
-          </div>
-        </div>
-        <div class="bx--col">
-          <div class="outside">
-            <div class="inside">
-              1
-            </div>
-          </div>
-        </div>
-        <div class="bx--col">
-          <div class="outside">
-            <div class="inside">
-              1
-            </div>
-          </div>
-        </div>
-        <div class="bx--col">
-          <div class="outside">
-            <div class="inside">
-              1
-            </div>
-          </div>
-        </div>
-        <div class="bx--col">
-          <div class="outside">
-            <div class="inside">
-              1
-            </div>
-          </div>
-        </div>
-        <div class="bx--col">
-          <div class="outside">
-            <div class="inside">
-              1
-            </div>
-          </div>
-        </div>
-        <div class="bx--col">
-          <div class="outside">
-            <div class="inside">
-              1
-            </div>
-          </div>
-        </div>
-        <div class="bx--col">
-          <div class="outside">
-            <div class="inside">
-              1
-            </div>
-          </div>
-        </div>
-        <div class="bx--col">
-          <div class="outside">
-            <div class="inside">
-              1
-            </div>
-          </div>
-        </div>
-        <div class="bx--col">
-          <div class="outside">
-            <div class="inside">
-              1
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="bx--row">
-        <div class="bx--col">
-          <div class="outside">
-            <div class="inside">
-              1/4
-            </div>
-          </div>
-        </div>
-        <div class="bx--col">
-          <div class="outside">
-            <div class="inside">
-              1/4
-            </div>
-          </div>
-        </div>
-        <div class="bx--col">
-          <div class="outside">
-            <div class="inside">
-              1/4
-            </div>
-          </div>
-        </div>
-        <div class="bx--col">
-          <div class="outside">
-            <div class="inside">
-              1/4
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="bx--row">
-        <div class="bx--col">
-          <div class="outside">
-            <div class="inside">
-              1/2
-            </div>
-          </div>
-        </div>
-        <div class="bx--col">
-          <div class="outside">
-            <div class="inside">
-              1/2
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="bx--row">
-        <div class="bx--col-sm-12 bx--col-md-4">
-          <div class="outside">
-            <div class="inside">
-              1/2
-            </div>
-          </div>
-        </div>
-        <div class="bx--col-sm-4 bx--col-md-4">
-          <div class="outside">
-            <div class="inside">
-              1/2
+          <div class="bx--col-sm-4 bx--col-md-4">
+            <div class="outside">
+              <div class="inside">
+                1/2
+              </div>
             </div>
           </div>
         </div>
@@ -195,26 +192,28 @@ export const Basic = () => ({
 
 export const ResponsiveBreakpoints = () => ({
   template: `
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-1 bx--col-md-2 bx--col-lg-4">
-          <div class="outside">
-            <div class="inside">Content</div>
+    <div class="grid-demo">
+      <div class="bx--grid">
+        <div class="bx--row">
+          <div class="bx--col-sm-1 bx--col-md-2 bx--col-lg-4">
+            <div class="outside">
+              <div class="inside">Content</div>
+            </div>
           </div>
-        </div>
-        <div class="bx--col-sm-1 bx--col-md-2 bx--col-lg-6">
-          <div class="outside">
-            <div class="inside">Content</div>
+          <div class="bx--col-sm-1 bx--col-md-2 bx--col-lg-6">
+            <div class="outside">
+              <div class="inside">Content</div>
+            </div>
           </div>
-        </div>
-        <div class="bx--col-sm-1 bx--col-md-2 bx--col-lg-4">
-          <div class="outside">
-            <div class="inside">Content</div>
+          <div class="bx--col-sm-1 bx--col-md-2 bx--col-lg-4">
+            <div class="outside">
+              <div class="inside">Content</div>
+            </div>
           </div>
-        </div>
-        <div class="bx--col-sm-1 bx--col-md-2 bx--col-lg-2">
-          <div class="outside">
-            <div class="inside">Content</div>
+          <div class="bx--col-sm-1 bx--col-md-2 bx--col-lg-2">
+            <div class="outside">
+              <div class="inside">Content</div>
+            </div>
           </div>
         </div>
       </div>
@@ -224,116 +223,118 @@ export const ResponsiveBreakpoints = () => ({
 
 export const Offset = () => ({
   template: `
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--offset-lg-15 bx--col-lg-1">
-          <div class="outside">
-            <div class="inside">1</div>
+    <div class="grid-demo">
+      <div class="bx--grid">
+        <div class="bx--row">
+          <div class="bx--offset-lg-15 bx--col-lg-1">
+            <div class="outside">
+              <div class="inside">1</div>
+            </div>
           </div>
         </div>
-      </div>
-      <div class="bx--row">
-        <div class="bx--offset-lg-14 bx--col-lg-2">
-          <div class="outside">
-            <div class="inside">2</div>
+        <div class="bx--row">
+          <div class="bx--offset-lg-14 bx--col-lg-2">
+            <div class="outside">
+              <div class="inside">2</div>
+            </div>
           </div>
         </div>
-      </div>
-      <div class="bx--row">
-        <div class="bx--offset-lg-13 bx--col-lg-3">
-          <div class="outside">
-            <div class="inside">3</div>
+        <div class="bx--row">
+          <div class="bx--offset-lg-13 bx--col-lg-3">
+            <div class="outside">
+              <div class="inside">3</div>
+            </div>
           </div>
         </div>
-      </div>
-      <div class="bx--row">
-        <div class="bx--offset-lg-12 bx--col-lg-4">
-          <div class="outside">
-            <div class="inside">4</div>
+        <div class="bx--row">
+          <div class="bx--offset-lg-12 bx--col-lg-4">
+            <div class="outside">
+              <div class="inside">4</div>
+            </div>
           </div>
         </div>
-      </div>
-      <div class="bx--row">
-        <div class="bx--offset-lg-11 bx--col-lg-5">
-          <div class="outside">
-            <div class="inside">5</div>
+        <div class="bx--row">
+          <div class="bx--offset-lg-11 bx--col-lg-5">
+            <div class="outside">
+              <div class="inside">5</div>
+            </div>
           </div>
         </div>
-      </div>
-      <div class="bx--row">
-        <div class="bx--offset-lg-10 bx--col-lg-6">
-          <div class="outside">
-            <div class="inside">6</div>
+        <div class="bx--row">
+          <div class="bx--offset-lg-10 bx--col-lg-6">
+            <div class="outside">
+              <div class="inside">6</div>
+            </div>
           </div>
         </div>
-      </div>
-      <div class="bx--row">
-        <div class="bx--offset-lg-9 bx--col-lg-7">
-          <div class="outside">
-            <div class="inside">7</div>
+        <div class="bx--row">
+          <div class="bx--offset-lg-9 bx--col-lg-7">
+            <div class="outside">
+              <div class="inside">7</div>
+            </div>
           </div>
         </div>
-      </div>
-      <div class="bx--row">
-        <div class="bx--offset-lg-8 bx--col-lg-8">
-          <div class="outside">
-            <div class="inside">8</div>
+        <div class="bx--row">
+          <div class="bx--offset-lg-8 bx--col-lg-8">
+            <div class="outside">
+              <div class="inside">8</div>
+            </div>
           </div>
         </div>
-      </div>
-      <div class="bx--row">
-        <div class="bx--offset-lg-7 bx--col-lg-9">
-          <div class="outside">
-            <div class="inside">9</div>
+        <div class="bx--row">
+          <div class="bx--offset-lg-7 bx--col-lg-9">
+            <div class="outside">
+              <div class="inside">9</div>
+            </div>
           </div>
         </div>
-      </div>
-      <div class="bx--row">
-        <div class="bx--offset-lg-6 bx--col-lg-10">
-          <div class="outside">
-            <div class="inside">10</div>
+        <div class="bx--row">
+          <div class="bx--offset-lg-6 bx--col-lg-10">
+            <div class="outside">
+              <div class="inside">10</div>
+            </div>
           </div>
         </div>
-      </div>
-      <div class="bx--row">
-        <div class="bx--offset-lg-5 bx--col-lg-11">
-          <div class="outside">
-            <div class="inside">11</div>
+        <div class="bx--row">
+          <div class="bx--offset-lg-5 bx--col-lg-11">
+            <div class="outside">
+              <div class="inside">11</div>
+            </div>
           </div>
         </div>
-      </div>
-      <div class="bx--row">
-        <div class="bx--offset-lg-4 bx--col-lg-12">
-          <div class="outside">
-            <div class="inside">12</div>
+        <div class="bx--row">
+          <div class="bx--offset-lg-4 bx--col-lg-12">
+            <div class="outside">
+              <div class="inside">12</div>
+            </div>
           </div>
         </div>
-      </div>
-      <div class="bx--row">
-        <div class="bx--offset-lg-3 bx--col-lg-13">
-          <div class="outside">
-            <div class="inside">13</div>
+        <div class="bx--row">
+          <div class="bx--offset-lg-3 bx--col-lg-13">
+            <div class="outside">
+              <div class="inside">13</div>
+            </div>
           </div>
         </div>
-      </div>
-      <div class="bx--row">
-        <div class="bx--offset-lg-2 bx--col-lg-14">
-          <div class="outside">
-            <div class="inside">14</div>
+        <div class="bx--row">
+          <div class="bx--offset-lg-2 bx--col-lg-14">
+            <div class="outside">
+              <div class="inside">14</div>
+            </div>
           </div>
         </div>
-      </div>
-      <div class="bx--row">
-        <div class="bx--offset-lg-1 bx--col-lg-15">
-          <div class="outside">
-            <div class="inside">15</div>
+        <div class="bx--row">
+          <div class="bx--offset-lg-1 bx--col-lg-15">
+            <div class="outside">
+              <div class="inside">15</div>
+            </div>
           </div>
         </div>
-      </div>
-      <div class="bx--row">
-        <div class="bx--offset-lg-0 bx--col-lg-16">
-          <div class="outside">
-            <div class="inside">16</div>
+        <div class="bx--row">
+          <div class="bx--offset-lg-0 bx--col-lg-16">
+            <div class="outside">
+              <div class="inside">16</div>
+            </div>
           </div>
         </div>
       </div>
@@ -343,26 +344,28 @@ export const Offset = () => ({
 
 export const HideColumns = () => ({
   template: `
-    <div class="bx--grid">
-      <div class="bx--row">
-        <div class="bx--col-sm-1 bx--col-md-2 bx--col-lg-6">
-          <div class="outside">
-            <div class="inside">Never Hidden</div>
+    <div class="grid-demo">
+      <div class="bx--grid">
+        <div class="bx--row">
+          <div class="bx--col-sm-1 bx--col-md-2 bx--col-lg-6">
+            <div class="outside">
+              <div class="inside">Never Hidden</div>
+            </div>
           </div>
-        </div>
-        <div class="bx--col-sm-2 bx--col-md-0 bx--col-lg-6">
-          <div class="outside">
-            <div class="inside">Hidden on Medium Screens</div>
+          <div class="bx--col-sm-2 bx--col-md-0 bx--col-lg-6">
+            <div class="outside">
+              <div class="inside">Hidden on Medium Screens</div>
+            </div>
           </div>
-        </div>
-        <div class="bx--col-sm-0 bx--col-md-3 bx--col-lg-4">
-          <div class="outside">
-            <div class="inside">Hidden on Small Screens</div>
+          <div class="bx--col-sm-0 bx--col-md-3 bx--col-lg-4">
+            <div class="outside">
+              <div class="inside">Hidden on Small Screens</div>
+            </div>
           </div>
-        </div>
-        <div class="bx--col-sm-1 bx--col-md-3 bx--col-lg-0">
-          <div class="outside">
-            <div class="inside">Hidden on Large Screens</div>
+          <div class="bx--col-sm-1 bx--col-md-3 bx--col-lg-0">
+            <div class="outside">
+              <div class="inside">Hidden on Large Screens</div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
# Description
The purpose of this PR is to fix an issue with the table docs. I added a decorator for the Grid to wrap each story in a `.demo-grid` div, but that somehow altered all stories.  

## Before
![nih-sparc github io_sparc-design-system-components_(Laptop with MDPI screen)](https://user-images.githubusercontent.com/1493195/89927878-ff3da080-dbd4-11ea-8bf1-ecefcd4b3d42.png)

## After
![localhost_6006__path=_story_components-table--primary(Laptop with MDPI screen)](https://user-images.githubusercontent.com/1493195/89927908-0795db80-dbd5-11ea-89f5-05dacce2ce1e.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Load the Table docs
- Table should no longer have blue background and its cells should not have a blue dashed border

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have pushed the final commit message using the [changelog format](https://github.com/nih-sparc/sparc-design-system-components/wiki/Generating-a-Changelog)
