### PR TITLE
Added select

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -58,6 +58,25 @@
           <el-button slot="item">{{ dir }}</el-button>
         </sparc-tooltip>
       </div>
+      <el-row type="flex" justify="center">
+        <el-select
+          v-model="selectVal"
+          placeholder="Select"
+        >
+          <el-option-group
+            v-for="group in selectOpts"
+            :key="group.label"
+            :label="group.label"
+          >
+            <el-option
+              v-for="item in group.options"
+              :key="item.value"
+              :label="item.label"
+              :value="item.value">
+            </el-option>
+          </el-option-group>
+        </el-select>
+      </el-row>
     </div>
   </div>
 </template>
@@ -136,6 +155,35 @@ export default {
         'right-top',
         'right-center',
         'right-bottom'
+      ],
+      selectVal: [],
+      selectOpts: [
+        {
+          label: 'Group 1',
+          options: [
+            {
+              value: 'Option1',
+              label: 'Option 1'
+            },
+            {
+              value: 'Option2',
+              label: 'Option 2'
+            },
+          ]
+        },
+        {
+          label: 'Group 2',
+          options: [
+            {
+              value: 'Option3',
+              label: 'Option 3'
+            },
+            {
+              value: 'Option4',
+              label: 'Option 4'
+            },
+          ]
+        },
       ]
     }
   },

--- a/src/assets/components/_el-select.scss
+++ b/src/assets/components/_el-select.scss
@@ -1,5 +1,44 @@
 @import '../_variables.scss';
 
-.el-select .el-input .el-select__caret {
+.el-select {
+  &.secondary {
+    .el-input {
+      input {
+        border-color: lightgray;
+      }
+    }
+  }
+  .el-input {
+    &.is-disabled {
+      input {
+        border-color: $mediumGrey;
+      }
+      .el-select__caret {
+        color: $lightGrey;
+      }
+      .el-input__inner {
+        &:hover {
+          border-color: $mediumGrey !important;
+        }
+      }
+    }
+    .el-select__caret {
+      color: $mediumGrey;
+    }
+  }
+}
+
+.el-select-group__title {
   color: $mediumGrey;
+  font-size: 14px;
+  font-weight: bold;
+}
+
+// HACK: The only way to edit the icon in the select
+// input box is to directly change the content value
+// of the <i> tag.
+.el-icon-arrow-up {
+  &::before {
+    content: ''
+  }
 }

--- a/src/stories/select/select.stories.js
+++ b/src/stories/select/select.stories.js
@@ -1,0 +1,160 @@
+import './demo-styles.scss';
+
+export default {
+  title: 'Components/Select',
+  includeStories: []
+}
+
+const defaultOpts = [{
+  value: 'Option1',
+  label: 'Option 1'
+}, {
+  value: 'Option2',
+  label: 'Option 2'
+}, {
+  value: 'Option3',
+  label: 'Option 3'
+}, {
+  value: 'Option4',
+  label: 'Option 4'
+}, {
+  value: 'Option5',
+  label: 'Option 5'
+}]
+
+const createSelect = (
+  options,
+  placeholder = 'Select',
+  size = 'large',
+  disabled = false,
+  secondary = false
+) => {
+  return {
+    data() {
+      return {
+        options: options,
+        value: '',
+        placeholder: placeholder,
+        size: size,
+        disabled: disabled,
+        secondary: secondary
+      }
+    },
+    template: `
+      <el-select
+        v-model="value"
+        :placeholder=placeholder
+        :size=size
+        :disabled=disabled
+        :class="[secondary ? 'secondary' : '']"
+      >
+        <el-option
+          v-for="item in options"
+          :key="item.value"
+          :label="item.label"
+          :value="item.value">
+        </el-option>
+      </el-select>
+    `
+  }
+}
+
+export const Primary = () => createSelect(
+  defaultOpts
+)
+
+export const Secondary = () => createSelect(
+  defaultOpts,
+  undefined,
+  undefined,
+  undefined,
+  true
+)
+
+export const Disabled = () => createSelect(
+  defaultOpts,
+  undefined,
+  undefined,
+  true,
+  undefined
+)
+
+export const Large = () => createSelect(
+  defaultOpts
+)
+
+export const Medium = () => createSelect(
+  defaultOpts,
+  undefined,
+  'medium',
+  undefined,
+  undefined
+)
+
+export const Small = () => createSelect(
+  defaultOpts,
+  undefined,
+  'small',
+  undefined,
+  undefined
+)
+
+export const Placeholder = () => createSelect(
+  defaultOpts,
+  'PLACEHOLDER',
+  undefined,
+  undefined,
+  undefined
+)
+
+export const Grouping = () => ({
+  data() {
+    return {
+      options: [
+        {
+          label: 'Group 1',
+          options: [
+            {
+              value: 'Option1',
+              label: 'Option 1'
+            },
+            {
+              value: 'Option2',
+              label: 'Option 2'
+            },
+          ]
+        },
+        {
+          label: 'Group 2',
+          options: [
+            {
+              value: 'Option3',
+              label: 'Option 3'
+            },
+            {
+              value: 'Option4',
+              label: 'Option 4'
+            },
+          ]
+        },
+      ],
+      value: []
+    }
+  },
+  template: `
+    <el-select v-model="value">
+      <el-option-group
+      v-for="group in options"
+      :key="group.label"
+      :label="group.label"
+      >
+        <el-option
+          v-for="item in group.options"
+          :key="item.value"
+          :label="item.label"
+          :value="item.value">
+        </el-option>
+      </el-option-group>
+    </el-select>
+  `
+})

--- a/src/stories/select/select.stories.mdx
+++ b/src/stories/select/select.stories.mdx
@@ -1,0 +1,178 @@
+import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import * as stories from './select.stories.js';
+
+<Meta title="Components/Select" />
+
+# Select
+Select inputs can be used when it is desired to display several options and allow the user to select one. The component requires a value to bind to using `v-model`.
+
+<Story name="Normal">{stories.Primary()}</Story>
+
+#### Code
+```html
+<el-select v-model="value">
+  <el-option
+    v-for="item in options"
+    :key="item.value"
+    :label="item.label"
+    :value="item.value">
+  </el-option>
+</el-select>
+```
+
+```js
+export default {
+  data() {
+    return {
+      options: [{
+        value: 'Option1',
+        label: 'Option 1'
+      }, {
+        value: 'Option2',
+        label: 'Option 2'
+      }, {
+        value: 'Option3',
+        label: 'Option 3'
+      }, {
+        value: 'Option4',
+        label: 'Option 4'
+      }, {
+        value: 'Option5',
+        label: 'Option 5'
+      }],
+      value: ''
+    }
+  }
+}
+```
+
+# Size
+By default, the size of the select menu is large. Other sizes can be attained by passing in the `size` prop.
+
+### Large
+<Story name="Large">{stories.Large()}</Story>
+
+#### Code
+```html
+<el-select v-model="value" size="large">
+  ...
+</el-select>
+```
+
+### Medium
+<Story name="Medium">{stories.Medium()}</Story>
+
+#### Code
+```html
+<el-select v-model="value" size="medium">
+  ...
+</el-select>
+```
+
+### Small
+<Story name="Small">{stories.Small()}</Story>
+
+#### Code
+```html
+<el-select v-model="value" size="small">
+  ...
+</el-select>
+```
+
+# Disabled
+A select input may be disabled by passing in a boolean value to the `disabled` prop.
+
+<Story name="Disabled">{stories.Disabled()}</Story>
+
+#### Code
+```html
+<el-select v-model="value" :disabled="true">
+  ...
+</el-select>
+```
+
+# Secondary
+The secondary styling can be used by applying the `secondary` class.
+
+<Story name="Secondary">{stories.Secondary()}</Story>
+
+#### Code
+```html
+<el-select v-model="value" class="secondary">
+  ...
+</el-select>
+```
+
+# Placeholder
+The placeholder in the input can be customized with the `placeholder` prop.
+
+<Story name="Placeholder">{stories.Placeholder()}</Story>
+
+#### Code
+```html
+<el-select v-model="value" placeholder="PLACEHOLDER">
+  ...
+</el-select>
+```
+
+# Grouping
+Options can be categorized in groups and displayed with a label for each group.
+
+<Story name="Grouping">{stories.Grouping()}</Story>
+
+#### Code
+```html
+<el-select v-model="value">
+  <el-option-group
+  v-for="group in options"
+  :key="group.label"
+  :label="group.label"
+  >
+    <el-option
+      v-for="item in group.options"
+      :key="item.value"
+      :label="item.label"
+      :value="item.value">
+    </el-option>
+  </el-option-group>
+</el-select>
+```
+
+```js
+export default {
+  data() {
+    return {
+      options: [
+        {
+          label: 'Group 1',
+          options: [
+            {
+              value: 'Option1',
+              label: 'Option 1'
+            },
+            {
+              value: 'Option2',
+              label: 'Option 2'
+            },
+          ]
+        },
+        {
+          label: 'Group 2',
+          options: [
+            {
+              value: 'Option3',
+              label: 'Option 3'
+            },
+            {
+              value: 'Option4',
+              label: 'Option 4'
+            },
+          ]
+        },
+      ],
+      value: []
+    }
+  }
+}
+```
+


### PR DESCRIPTION
# Description

Added the Select input to both the SPARC design system and the storybook. This includes the regular select and grouping options. Multiselect is not implemented yet.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Verify that the storybook follows the [Abstract designs](https://app.abstract.com/share/e17695cc-fc3c-4007-8814-4012547a2efe?collectionId=ed37ad59-75c5-496f-8bc4-2b7066d0bbd9&collectionLayerId=0016fce0-2346-4d91-b9dc-8319b1ed612e&present=true&preview=false&sha=9b4c7ac502cad094b352d225a16389b3d526ff0d).


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have pushed the final commit message using the [changelog format](https://github.com/nih-sparc/sparc-design-system-components/wiki/Generating-a-Changelog)
