### PR TITLE
fixed safari issue with close icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nih-sparc/sparc-design-system-components",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "private": false,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/LargeModal/src/LargeModal.vue
+++ b/src/components/LargeModal/src/LargeModal.vue
@@ -106,14 +106,9 @@ export default {
     background: none;
     border: none;
     cursor: pointer;
-    padding: 0;
+    padding: .25rem .25rem 0 0;
     position: absolute;
-    right: 41px;
-  }
-
-  .close-icon {
-    margin-top: 12px;
-    margin-right: -36px;
+    right: 0;
   }
 
   ::v-deep .el-dialog {


### PR DESCRIPTION
# Description

Safari was not displaying close icon for modal

## Type of change

_Delete those that don't apply._

- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Locally
