### PR TITLE
Fix dropdown multiselect show all node visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nih-sparc/sparc-design-system-components",
-  "version": "0.26.4",
+  "version": "0.26.5",
   "private": false,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/DropdownMultiselect/src/DropdownMultiselect.vue
+++ b/src/components/DropdownMultiselect/src/DropdownMultiselect.vue
@@ -8,7 +8,7 @@
       :show-collapsible-arrow="!hasSingleNode"
     >
       <hr v-show="!hasSingleNode" />
-      <div v-show="!hideShowAllOption" class="show-all-node">
+      <div v-show="!hasSingleNode" class="show-all-node mx-24 my-8">
         <el-checkbox v-model="showAll" @change="onChangeShowAll">
           <span>Show all</span>
         </el-checkbox>
@@ -16,7 +16,7 @@
       </div>
       <div
         :class="[
-          'padding-bottom',
+          'pb-8',
           {
             'light-gray-background': !hasSingleNode,
             'white-background': hasSingleNode
@@ -97,10 +97,6 @@ export default {
       type: Array,
       default: () => []
     },
-    checkAllByDefault: {
-      type: Boolean,
-      default: true
-    }
   },
   data() {
     return {
@@ -139,21 +135,6 @@ export default {
       }
     },
     defaultCheckedKeys: function() {
-      // if we are not rendering the show all node then we manually select all of them by default unless the checkAllByDefault prop is set to false
-      if(this.hideShowAllOption && !this.defaultCheckedIds.length && this.checkAllByDefault) {
-        if (this.visibleData === undefined) {
-          return pluck('id', this.category.data)
-        }
-        else {
-          let visibleDefaultIds = []
-          this.category.data.forEach(item => {
-            if (this.allVisibleDataIds.includes(item.label)) {
-              visibleDefaultIds.push(item.id)
-            }
-          })
-          return visibleDefaultIds
-        }
-      }
       return this.defaultCheckedIds
     },
     totalVisibleNodes: function() {
@@ -191,9 +172,6 @@ export default {
     hasSingleNode: function() {
       return this.numFirstLevelNodes === 1
     },
-    hideShowAllOption: function() {
-      return this.numFirstLevelNodes < 5
-    },
     showExpandOptionsContainer: function() {
       return this.numFirstLevelNodes > 9
     },
@@ -227,7 +205,7 @@ export default {
     renderContent(h, { node, data, store }) {
       return (
         <el-tooltip
-          placement="top-end"
+          placement="right"
           transition="none"
           open-delay={tooltipDelay}
         >
@@ -263,14 +241,6 @@ export default {
             }
             return false
           }
-        }
-        if (this.hideShowAllOption && this.numOptionsShown < 5) {
-          if (this.allVisibleDataIds.includes(data.label))
-          {
-            this.numOptionsShown += 1
-            return true
-          }
-          return false
         }
         return this.allVisibleDataIds.includes(data.label)
       }
@@ -310,7 +280,7 @@ export default {
     },
     setShowAll: function() {
       const checkedNodes = this.visibleCheckedNodes
-      if ((!checkedNodes.length || checkedNodes.length === this.totalVisibleNodes) && !this.hideShowAllOption) {
+      if ((!checkedNodes.length || checkedNodes.length === this.totalVisibleNodes) && !this.hasSingleNode) {
         this.showAll = true
         this.$nextTick(() => { 
           this.uncheckAll() 
@@ -333,8 +303,8 @@ export default {
 
 ::v-deep .show-all-node {
   .el-checkbox__label {
-      font-weight: normal;
-    }
+    font-weight: normal;
+  }
 }
 ::v-deep .el-tree-node.is-checked {
   .custom-tree-node {
@@ -378,13 +348,9 @@ export default {
     margin-top: 0.5rem;
     margin-bottom: 0;
   }
-  margin: 0.5rem 1.5rem;
 }
 .white-background {
   background: white;
-}
-.padding-bottom {
-  padding-bottom: 0.5rem;
 }
 .expand-options-container {
   color: $purple;

--- a/src/stories/dropdownMultiselect/dropdownMultiselect.stories.mdx
+++ b/src/stories/dropdownMultiselect/dropdownMultiselect.stories.mdx
@@ -17,8 +17,6 @@ Any nested parent data must have a children property where their childrens label
 
 `defaultCheckedIds`: The ids of any nodes that should be checked by default. Array. Optional.
 
-`checkAllByDefault`: When the 'show all' option is not displayed, setting this to false will stop the dropdown from selecting all the options by default. Boolean. Optional. Default value is true.
-
 `visibleData`: The data that you want to be shown. Object. Optional. Setting this property is not reccomended for normal use cases and is available for the
 sole purpose of allowing the sparc portal's 'data' and 'models and simulations' tabs share a dropdown. If not set, all the data will be shown as expected.
 The visible data must have the categories id as a property on the object. Inside this object you can then specify the label of every selection that should be visible as a property of the object.


### PR DESCRIPTION
# Description

After talking to Dominic it was decided to display show all node at all times except for when there is a single option

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally
