### PR TITLE
updated help icon in dropdown multiselect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nih-sparc/sparc-design-system-components",
-  "version": "0.26.11",
+  "version": "0.26.12",
   "private": false,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/DropdownMultiselect/src/DropdownLabel.vue
+++ b/src/components/DropdownMultiselect/src/DropdownLabel.vue
@@ -6,7 +6,7 @@
         <span class="label-title">{{ label }}</span>
         <el-tooltip placement="top-start" transition="none">
           <div slot="content" v-html="tooltip">{{tooltip}}</div>
-          <svgicon v-if="showHelpIcon" class="purple-fill" icon="help" width="26" height="26" />
+          <svgicon v-if="showHelpIcon" class="ml-4 help-icon" icon="help" width="20" height="20" />
         </el-tooltip>
       </span>
       <svgicon
@@ -108,8 +108,9 @@ export default {
   font-weight: 500;
 }
 
-.purple-fill {
+.help-icon {
   fill: $purple;
+  vertical-align: text-top;
 }
 
 hr {


### PR DESCRIPTION
# Description

updated help icon in dropdown multiselect to be smaller and vertically aligned

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally
