### PR TITLE
Add ability to expand/collapse categories remotely

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nih-sparc/sparc-design-system-components",
-  "version": "0.26.15",
+  "version": "0.26.16",
   "private": false,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/DropdownMultiselect/src/DropdownLabel.vue
+++ b/src/components/DropdownMultiselect/src/DropdownLabel.vue
@@ -76,6 +76,9 @@ export default {
         this.collapsed = !this.collapsed
       }
       return this.collapsed
+    },
+    setCollapsed(isCollapsed) {
+      this.collapsed = isCollapsed
     }
   }
 }

--- a/src/components/DropdownMultiselect/src/DropdownMultiselect.vue
+++ b/src/components/DropdownMultiselect/src/DropdownMultiselect.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="sparc-design-system-component-dropdown-multiselect">
     <dropdown-label
+      ref="label"
       :disabled="!enabled"
       :label="category.label"
       :tooltip="tooltip"
@@ -251,6 +252,9 @@ export default {
       } else {
         this.showAll = false
       }
+    },
+    setCollapsed: function(isCollapsed) {
+      this.$refs.label.setCollapsed(isCollapsed)
     }
   }
 }


### PR DESCRIPTION
# Description

Added a setCollapsed method so users can collapse a category programmatically instead of only via the dropdown arrow button

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally
