### PR TITLE
Added ability to programmatically hide tooltips

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nih-sparc/sparc-design-system-components",
-  "version": "0.26.16",
+  "version": "0.26.17",
   "private": false,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/SparcTooltip/src/SparcTooltip.vue
+++ b/src/components/SparcTooltip/src/SparcTooltip.vue
@@ -1,7 +1,7 @@
 <template>
   <el-tooltip
     :content="content"
-    :disabled="disabled"
+    :disabled="isDisabled"
     :placement="mappedPlacement"
   >
     <div v-if="!content" slot="content">
@@ -29,6 +29,12 @@ const PLACEMENTS = Object.freeze({
 export default {
   name: 'SparcTooltip',
 
+  data() {
+    return {
+      hidden: false
+    }
+  },
+
   props: {
     content: {
       type: String,
@@ -54,7 +60,16 @@ export default {
      */
     mappedPlacement: function() {
       return PLACEMENTS[this.placement.toLowerCase()]
-    }
+    },
+    isDisabled: function() {
+      return this.disabled || this.hidden
+    },
   },
+
+  methods: {
+    hide(isHidden) {
+      this.hidden = isHidden
+    }
+  }
 }
 </script>


### PR DESCRIPTION
# Description

Add method to allow client to programmatically show/hide the sparc-tooltip


## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally via App.js

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
