### PR TITLE
Added prop to Sparc Tooltip to hide content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nih-sparc/sparc-design-system-components",
-  "version": "0.26.17",
+  "version": "0.26.18",
   "private": false,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/App.vue
+++ b/src/App.vue
@@ -134,6 +134,10 @@
           <el-button slot="item">{{ dir }}</el-button>
         </sparc-tooltip>
       </div>
+      <sparc-tooltip placement="top-center" is-repeating-item-content>
+        <div slot="data">Only show this tooltip if content is cutoff</div>
+        <p slot="item">Only show tooltip when this has ellipsis</p>
+      </sparc-tooltip>
       <el-row type="flex" justify="center">
         <el-select
           v-model="selectVal"
@@ -342,9 +346,10 @@
 <script>
 import { successMessage, failMessage, informationNotification, iconInformationNotification } from "../utils/notificationMessages"
 import BreadcrumbTrail from './components/BreadcrumbTrail/src/BreadcrumbTrail.vue'
+import SparcTooltip from './components/SparcTooltip/src/SparcTooltip.vue'
 
 export default {
-  components: { BreadcrumbTrail },
+  components: { BreadcrumbTrail, SparcTooltip },
   name: 'App',
 
   data() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -346,10 +346,9 @@
 <script>
 import { successMessage, failMessage, informationNotification, iconInformationNotification } from "../utils/notificationMessages"
 import BreadcrumbTrail from './components/BreadcrumbTrail/src/BreadcrumbTrail.vue'
-import SparcTooltip from './components/SparcTooltip/src/SparcTooltip.vue'
 
 export default {
-  components: { BreadcrumbTrail, SparcTooltip },
+  components: { BreadcrumbTrail },
   name: 'App',
 
   data() {

--- a/src/components/SparcTooltip/src/SparcTooltip.vue
+++ b/src/components/SparcTooltip/src/SparcTooltip.vue
@@ -7,7 +7,9 @@
     <div v-if="!content" slot="content">
       <slot name="data"></slot>
     </div>
-    <slot name="item"></slot>
+    <div class="tooltip-item" @mouseenter="onEnterTooltip">
+      <slot name="item"></slot>
+    </div>
   </el-tooltip>
 </template>
 
@@ -50,6 +52,10 @@ export default {
     disabled: {
       type: Boolean,
       default: false
+    },
+    isRepeatingItemContent: {
+      type: Boolean,
+      default: false
     }
   },
 
@@ -69,7 +75,21 @@ export default {
   methods: {
     hide(isHidden) {
       this.hidden = isHidden
+    },
+    onEnterTooltip(e) {
+      // Hide the tooltip if it is simply repeating the items content and the items content is not cut off
+      if (!this.isRepeatingItemContent) { return }
+      const target = e.target
+      this.hidden = target.scrollWidth <= target.offsetWidth
     }
   }
 }
 </script>
+<style lang="scss" scoped>
+.tooltip-item {
+  display: flex;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+</style>


### PR DESCRIPTION
# Description

Moved logic to hide tooltip into the design system instead of calculating it in the sparc-app so that other cores can utilize it

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally via App.js

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
