### PR TITLE
Fix show all option bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nih-sparc/sparc-design-system-components",
-  "version": "0.26.22",
+  "version": "0.26.23",
   "private": false,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/DropdownMultiselect/src/DropdownMultiselect.vue
+++ b/src/components/DropdownMultiselect/src/DropdownMultiselect.vue
@@ -182,6 +182,9 @@ export default {
     },
     'visibleData': function() {
       this.setShowAll();
+    },
+    'defaultCheckedIds': function() {
+      this.setShowAll();
     }
   },
   mounted() {


### PR DESCRIPTION
# Description

Fix bug where dropdown multiselect would keep the show all option selected during a refresh even when other options are selected. It was working when visibleData was set, but if not setting visible data then it would not work and the consumer should not be required to set visibleData

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

