### PR TITLE
updated multiselect dropdown label

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nih-sparc/sparc-design-system-components",
-  "version": "0.26.25",
+  "version": "0.26.26",
   "private": false,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/DropdownMultiselect/src/DropdownLabel.vue
+++ b/src/components/DropdownMultiselect/src/DropdownLabel.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="{ disabled: disabled }">
-    <div class="label-header">
+    <div @click="onArrowClicked" :class="showCollapsibleArrow ? 'label-header-clickable' : ''" class="label-header">
       <span>
         <span class="label-title">{{ label }}</span>
         <el-tooltip placement="top-start" transition="none">
@@ -15,7 +15,6 @@
         :dir="collapsibleArrowDir"
         height="15"
         width="15"
-        @click="onArrowClicked"
       />
     </div>
     <div v-show="showContent" class="label-content-container">
@@ -72,7 +71,7 @@ export default {
   },
   methods: {
     onArrowClicked() {
-      if (!this.disabled) {
+      if (this.showCollapsibleArrow && !this.disabled) {
         this.collapsed = !this.collapsed
       }
       return this.collapsed
@@ -102,6 +101,10 @@ export default {
   svg {
     cursor: pointer
   }
+}
+
+.label-header-clickable {
+  cursor: pointer;
 }
 
 .label-title {


### PR DESCRIPTION
# Description

Made whole facet label clickable to expand/collapse facets as per: https://www.wrike.com/workspace.htm?acc=3203588#/task-view?id=970448610&pid=415614298&cid=415614298

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally via Storybook

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
