### PR TITLE
updated show collapsible arrow and bumped version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nih-sparc/sparc-design-system-components",
-  "version": "0.27.6",
+  "version": "0.27.7",
   "private": false,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/DropdownMultiselect/src/DropdownMultiselect.vue
+++ b/src/components/DropdownMultiselect/src/DropdownMultiselect.vue
@@ -6,7 +6,6 @@
       :label="category.label"
       :tooltip="tooltip"
       :collapse-by-default="collapseByDefault"
-      :show-collapsible-arrow="!hasSingleNode"
     >
       <hr v-show="!hasSingleNode" />
       <div v-show="!hasSingleNode" class="show-all-node mx-24 my-8">


### PR DESCRIPTION
# Description

Removed the check for a single node in the show collapse arrow so that it is always displayed. This was causing issues when getting facets from Algolia if there was only one returned

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have pushed the final commit message using the [changelog format](https://github.com/nih-sparc/sparc-design-system-components/wiki/Generating-a-Changelog)
